### PR TITLE
Change utf8 characters to ascii.

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -2,10 +2,10 @@ Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: <YOUR-REPO-NAME>
 Upstream-Contact: <YOUR-CONTACT (MAIL ADDRESS ETC.)>
 Source: <https://github.com/sap/YOUR-REPO-NAME>
-Disclaimer: The code in this project may include calls to APIs (“API Calls”) of
+Disclaimer: The code in this project may include calls to APIs ("API Calls") of
  SAP or third-party products or services developed outside of this project
- (“External Products”).
- “APIs” means application programming interfaces, as well as their respective
+ ("External Products").
+ "APIs" means application programming interfaces, as well as their respective
  specifications and implementing code that allows software to communicate with
  other software.
  API Calls to External Products are not licensed under the open source license
@@ -16,7 +16,7 @@ Disclaimer: The code in this project may include calls to APIs (“API Calls”)
  alter, expand or supersede any terms of the applicable additional agreements.
  If you have a valid license agreement with SAP for the use of a particular SAP
  External Product, then you may make use of any API Calls included in this
- project’s code for that SAP External Product, subject to the terms of such
+ project's code for that SAP External Product, subject to the terms of such
  license agreement. If you do not have a valid license agreement for the use of
  a particular SAP External Product, then you may only make use of any API Calls
  in this project for that SAP External Product for your internal, non-productive


### PR DESCRIPTION
The dep5 file contains utf-8 characters.
This is in general not an issue but can lead to issues if other
programs do not correctly handle utf8.
Unfortunately, the reuse tool does not handle utf8 characters
correctly. This can create a showstopper on windows.

The utf-8 characters in the dep5 file seem to be caused by
some word export where some special quotation marks were used.
We can simply replace them by regular ascii characters. This makes
the file both compatible to ascii and utf-8.

I will also send a fix to the reuse tool, but making the dep5 file
ascii compatible is still desirable as it allows to proceed now.