### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Code of Conduct
 
-All members of the project community must abide by the [Contributor Covenant, version 2.1](CODE_OF_CONDUCT.md).
+All members of the project community must abide by the [SAP Open Source Code of Conduct](https://github.com/SAP/.github/blob/main/CODE_OF_CONDUCT.md).
 Only by respecting each other we can develop a productive, collaborative community.
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting [a project maintainer](.reuse/dep5).
 


### PR DESCRIPTION
This seems to be a left over of https://github.com/SAP/repository-template/commit/e6fecd2221a931e8717ad62607139c09f2a63433.

It removed the code of conduct from the template repository and started pointing to the code of conduct at https://github.com/SAP/.github/blob/main/CODE_OF_CONDUCT.md (SAP Open Source Code of Conduct).

There is one thing we should probably check, the CoC removed by e6fecd2221a931e8717ad62607139c09f2a63433 was based on Contributor Covenant 2.1 - SAP Open Source Code of Conduct is based on Contributor Covenant 2.1, I did not check what changed from one to the other, but we may consider updating SAP Open Source Code of Conduct to be based on 2.1.

This was identified at the review of https://github.com/SAP/invoke-plugin-for-pylint.