### PR TITLE
add section about security policy to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ In case you are the maintainer of a new SAP open source project, these are the s
 This project is open to feature requests/suggestions, bug reports etc. via [GitHub issues](https://github.com/SAP/<your-project>/issues). Contribution and feedback are encouraged and always welcome. For more information about how to contribute, the project structure, as well as additional contribution information, see our [Contribution Guidelines](CONTRIBUTING.md).
 
 ## Security / Disclosure
-If you find any bug that may be a security problem, please follow our instructions at [our security page](https://github.com/SAP/<your-project>/security/policy). Please do not create GitHub issues for security-related doubts or problems.
+If you find any bug that may be a security problem, please follow our instructions at [in our security policy](https://github.com/SAP/<your-project>/security/policy) on how to report it. Please do not create GitHub issues for security-related doubts or problems.
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ In case you are the maintainer of a new SAP open source project, these are the s
 
 This project is open to feature requests/suggestions, bug reports etc. via [GitHub issues](https://github.com/SAP/<your-project>/issues). Contribution and feedback are encouraged and always welcome. For more information about how to contribute, the project structure, as well as additional contribution information, see our [Contribution Guidelines](CONTRIBUTING.md).
 
+## Security / Disclosure
+If you find any bug that may be a security problem, please follow our instructions at [our security page](https://github.com/SAP/<your-project>/security/policy). Please do not create GitHub issues for security-related doubts or problems.
+
 ## Code of Conduct
 
 We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone. By participating in this project, you agree to abide by its [Code of Conduct](https://github.com/SAP/.github/blob/main/CODE_OF_CONDUCT.md) at all times.


### PR DESCRIPTION
This PR adds a small section to the README to explicitly calls out the security disclosure process and includes a link to a projects security policy.